### PR TITLE
Relocating breakpoint indicator

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -154,19 +154,3 @@ dl {
 dd {
 	margin: 0 0 0 40px;
 }
-
-/* 	Breakpoint indicator
-	------------------------------------------------------- */
-.breakpoint-context {
-	position: absolute;
-    top: -999em;
-    left: -999em;
-	z-index: 1;
-
-	@include breakpoint($medium) {
-		z-index: 2;
-	}
-	@include breakpoint($large) {
-		z-index: 3;
-	}
-}

--- a/assets/scss/_utility.scss
+++ b/assets/scss/_utility.scss
@@ -72,3 +72,19 @@
 .h1 {
 	@extend h1;
 }
+
+/* 	Breakpoint indicator
+	------------------------------------------------------- */
+.breakpoint-context {
+	position: absolute;
+    top: -999em;
+    left: -999em;
+	z-index: 1;
+
+	@include breakpoint($medium) {
+		z-index: 2;
+	}
+	@include breakpoint($large) {
+		z-index: 3;
+	}
+}

--- a/assets/scss/_utility.scss
+++ b/assets/scss/_utility.scss
@@ -77,8 +77,8 @@
 	------------------------------------------------------- */
 .breakpoint-context {
 	position: absolute;
-    top: -999em;
-    left: -999em;
+	top: -999em;
+	left: -999em;
 	z-index: 1;
 
 	@include breakpoint($medium) {


### PR DESCRIPTION
- Moves breakpoint-context class to utilities partial so it can take advantage of the breakpoint mixin
